### PR TITLE
Remove: 'state_dict' for loading model from the official repo

### DIFF
--- a/convert_lsccnn_to_keras.py
+++ b/convert_lsccnn_to_keras.py
@@ -10,7 +10,7 @@ parser.add_argument('--pthpath',dest='pthpath',required=True,help="The path lead
 parser.add_argument('--savedir',dest='savedir',required=True,help="Where to save the model")
 
 def convert_torch_model_to_keras(pthpath):
-    weights_dict = torch.load(pthpath)['state_dict']
+    weights_dict = torch.load(pthpath)
     kmodel = build_LSCCNN_model()
     for layer in tqdm(kmodel.layers):
         layername = layer.name

--- a/convert_lsccnn_to_keras.py
+++ b/convert_lsccnn_to_keras.py
@@ -11,6 +11,8 @@ parser.add_argument('--savedir',dest='savedir',required=True,help="Where to save
 
 def convert_torch_model_to_keras(pthpath):
     weights_dict = torch.load(pthpath)
+    if 'state_dict' in weights_dict:
+    	weights_dict = weights_dict['state_dict']
     kmodel = build_LSCCNN_model()
     for layer in tqdm(kmodel.layers):
         layername = layer.name


### PR DESCRIPTION
The official repo only saves `state_dict` as the model, thus, the key is not required.